### PR TITLE
feat(workflow): implement LangGraph workflow orchestration

### DIFF
--- a/backend/app/graph/nodes/generator_node.py
+++ b/backend/app/graph/nodes/generator_node.py
@@ -1,0 +1,4 @@
+from app.services.generator.generator_node import generator_node as gen_service
+
+async def generator_node(state: dict):
+    return await gen_service(state)

--- a/backend/app/graph/nodes/rag_node.py
+++ b/backend/app/graph/nodes/rag_node.py
@@ -1,0 +1,4 @@
+from app.services.rag.rag_node import rag_node as rag_service
+
+async def rag_node(state: dict):
+    return await rag_service(state)

--- a/backend/app/graph/nodes/router_node.py
+++ b/backend/app/graph/nodes/router_node.py
@@ -1,0 +1,10 @@
+
+from app.services.query import route_query
+
+async def router_node(state: dict):
+    decision = route_query(state["question"])
+
+    return {
+        "route": decision.route,
+        "question": decision.question
+    }

--- a/backend/app/graph/state.py
+++ b/backend/app/graph/state.py
@@ -1,0 +1,8 @@
+from typing import TypedDict, List
+
+
+class AgentState(TypedDict):
+    question: str
+    route: str
+    context: List[str]
+    answer: str

--- a/backend/app/graph/workflow.py
+++ b/backend/app/graph/workflow.py
@@ -1,0 +1,40 @@
+# app/graph/workflow.py
+
+from langgraph.graph import StateGraph, END
+from app.graph.state import AgentState
+
+from app.graph.nodes.router_node import router_node
+from app.graph.nodes.rag_node import rag_node
+from app.graph.nodes.generator_node import generator_node
+
+
+def build_graph(
+    router=router_node,
+    rag=rag_node,
+    generator=generator_node
+):
+
+    workflow = StateGraph(AgentState)
+
+    workflow.add_node("router", router)
+    workflow.add_node("rag", rag)
+    workflow.add_node("generator", generator)
+
+    workflow.set_entry_point("router")
+
+    def route_condition(state):
+        return state["route"]
+
+    workflow.add_conditional_edges(
+        "router",
+        route_condition,
+        {
+            "search_docs": "rag",
+            "direct_answer": "generator"
+        }
+    )
+
+    workflow.add_edge("rag", "generator")
+    workflow.add_edge("generator", END)
+
+    return workflow.compile()

--- a/backend/app/services/generator/generator_node.py
+++ b/backend/app/services/generator/generator_node.py
@@ -1,7 +1,14 @@
 from app.llm.generator_chain import generator_chain
 
 def format_context(context: list) -> str:
-    return "\n".join(context) if context else ""
+    if not context:
+        return ""
+
+    # gérer dict ou string
+    return "\n".join(
+        item["content"] if isinstance(item, dict) else item
+        for item in context
+    )
 
 async def generator_node(state: dict) -> dict:
     question = state.get("question", "")

--- a/backend/tests/test_workflow.py
+++ b/backend/tests/test_workflow.py
@@ -1,0 +1,53 @@
+import pytest
+from app.graph.workflow import build_graph
+
+
+@pytest.mark.asyncio
+async def test_workflow_search_docs():
+
+    async def fake_router(state):
+        return {"route": "search_docs", "question": state["question"]}
+
+    async def fake_rag(state):
+        return {"context": ["API config doc"]}
+
+    async def fake_generator(state):
+        return {"answer": "Generated from context"}
+
+    graph = build_graph(
+        router=fake_router,
+        rag=fake_rag,
+        generator=fake_generator
+    )
+
+    result = await graph.ainvoke({
+        "question": "How to configure API?"
+    })
+
+    assert result["route"] == "search_docs"
+    assert result["context"] == ["API config doc"]
+    assert result["answer"] == "Generated from context"
+
+@pytest.mark.asyncio
+async def test_workflow_direct_answer():
+
+    async def fake_router(state):
+        return {"route": "direct_answer", "question": state["question"]}
+
+    async def fake_generator(state):
+        return {"answer": "Direct response"}
+
+    async def fake_rag(state):
+        raise Exception("RAG should not be called")
+
+    graph = build_graph(
+        router=fake_router,
+        rag=fake_rag,
+        generator=fake_generator
+    )
+
+    result = await graph.ainvoke({
+        "question": "Hello"
+    })
+
+    assert result["answer"] == "Direct response"


### PR DESCRIPTION
- Create typed AgentState for workflow state management
- Build graph with router → rag/generator conditional routing
- Create graph node wrappers for router, RAG, and generator
- Implement conditional edge logic based on routing decision
- Add comprehensive workflow integration tests
- Improve format_context to handle dict and string formats